### PR TITLE
Update Video.php: Fixes error `YoutubeDl\Entity\Video::getTags(): Ret…

### DIFF
--- a/src/Entity/Video.php
+++ b/src/Entity/Video.php
@@ -526,7 +526,7 @@ class Video extends AbstractEntity
      */
     public function getTags(): array
     {
-        return $this->get('tags');
+        return $this->get('tags', []);
     }
 
     public function toJson(int $options = JSON_THROW_ON_ERROR): string


### PR DESCRIPTION
…urn value must be of type array, null returned`